### PR TITLE
Add DistilBERT Modules

### DIFF
--- a/docs/code/data.rst
+++ b/docs/code/data.rst
@@ -22,6 +22,11 @@ Tokenizer
 .. autoclass:: texar.torch.data.BERTTokenizer
     :members:
 
+:hidden:`DistilBERTTokenizer`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: texar.torch.data.DistilBERTTokenizer
+    :members:
+
 :hidden:`GPT2Tokenizer`
 ~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: texar.torch.data.GPT2Tokenizer

--- a/docs/code/modules.rst
+++ b/docs/code/modules.rst
@@ -69,6 +69,11 @@ Encoders
 .. autoclass:: texar.torch.modules.RoBERTaEncoder
     :members:
 
+:hidden:`DistilBERTEncoder`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: texar.torch.modules.DistilBERTEncoder
+    :members:
+
 :hidden:`GPT2Encoder`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: texar.torch.modules.GPT2Encoder
@@ -229,6 +234,11 @@ Classifiers
 .. autoclass:: texar.torch.modules.RoBERTaClassifier
     :members:
 
+:hidden:`DistilBERTClassifier`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: texar.torch.modules.DistilBERTClassifier
+    :members:
+
 :hidden:`GPT2Classifier`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: texar.torch.modules.GPT2Classifier
@@ -273,6 +283,11 @@ Pre-trained
 :hidden:`PretrainedRoBERTaMixin`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: texar.torch.modules.PretrainedRoBERTaMixin
+    :members:
+
+:hidden:`PretrainedDistilBERTMixin`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: texar.torch.modules.PretrainedDistilBERTMixin
     :members:
 
 :hidden:`PretrainedGPT2Mixin`

--- a/texar/torch/data/tokenizers/__init__.py
+++ b/texar/torch/data/tokenizers/__init__.py
@@ -16,6 +16,7 @@ Tokenizer modules of Texar library.
 """
 
 from texar.torch.data.tokenizers.pretrained_bert_tokenizer import *
+from texar.torch.data.tokenizers.pretrained_distilbert_tokenizer import *
 from texar.torch.data.tokenizers.pretrained_gpt2_tokenizer import *
 from texar.torch.data.tokenizers.pretrained_roberta_tokenizer import *
 from texar.torch.data.tokenizers.tokenizer_base import *

--- a/texar/torch/data/tokenizers/pretrained_bert_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_bert_tokenizer.py
@@ -63,6 +63,17 @@ class BERTTokenizer(PretrainedBERTMixin, TokenizerBase):
         'bert-base-chinese': 512,
     }
     _VOCAB_FILE_NAMES = {'vocab_file': 'vocab.txt'}
+    _VOCAB_FILE_MAP = {
+        'vocab_file': {
+            'bert-base-uncased': 'vocab.txt',
+            'bert-large-uncased': 'vocab.txt',
+            'bert-base-cased': 'vocab.txt',
+            'bert-large-cased': 'vocab.txt',
+            'bert-base-multilingual-uncased': 'vocab.txt',
+            'bert-base-multilingual-cased': 'vocab.txt',
+            'bert-base-chinese': 'vocab.txt',
+        }
+    }
 
     def __init__(self,
                  pretrained_model_name: Optional[str] = None,
@@ -80,8 +91,10 @@ class BERTTokenizer(PretrainedBERTMixin, TokenizerBase):
         }
 
         if self.pretrained_model_dir is not None:
+            assert self.pretrained_model_name is not None
             vocab_file = os.path.join(self.pretrained_model_dir,
-                                      self._VOCAB_FILE_NAMES['vocab_file'])
+                                      self._VOCAB_FILE_MAP['vocab_file']
+                                      [self.pretrained_model_name])
             assert self.pretrained_model_name is not None
             if self._MAX_INPUT_SIZE.get(self.pretrained_model_name):
                 self.max_len = self._MAX_INPUT_SIZE[self.pretrained_model_name]

--- a/texar/torch/data/tokenizers/pretrained_distilbert_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_distilbert_tokenizer.py
@@ -1,0 +1,165 @@
+# Copyright 2019 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Pre-trained DistilBERT tokenizer.
+"""
+
+from texar.torch.data.tokenizers.pretrained_bert_tokenizer import BERTTokenizer
+
+__all__ = [
+    'DistilBERTTokenizer',
+]
+
+_DISTILBERT_PATH = "https://s3.amazonaws.com/models.huggingface.co/bert/"
+
+
+class DistilBERTTokenizer(BERTTokenizer):
+    r"""Pre-trained DistilBERT Tokenizer.
+    :class:`~texar.data.DistilBERTTokenizer` is identical to
+    :class:`~texar.data.BERTTokenizer`.
+
+    Args:
+        pretrained_model_name (optional): a `str`, the name of
+            pre-trained model (e.g., `distilbert-base-uncased`). Please refer to
+            :class:`~texar.torch.modules.PretrainedDistilBERTMixin` for
+            all supported models.
+            If None, the model name in :attr:`hparams` is used.
+        cache_dir (optional): the path to a folder in which the
+            pre-trained models will be cached. If `None` (default),
+            a default directory (``texar_data`` folder under user's home
+            directory) will be used.
+        hparams (dict or HParams, optional): Hyperparameters. Missing
+            hyperparameter will be set to default values. See
+            :meth:`default_hparams` for the hyperparameter structure
+            and default values.
+    """
+
+    _MODEL_NAME = "DistilBERT"
+    _MODEL2URL = {  # type: ignore
+        'distilbert-base-uncased': [
+            _DISTILBERT_PATH + 'distilbert-base-uncased-pytorch_model.bin',
+            _DISTILBERT_PATH + 'distilbert-base-uncased-config.json',
+            _DISTILBERT_PATH + 'bert-base-uncased-vocab.txt',
+        ],
+        'distilbert-base-uncased-distilled-squad': [
+            _DISTILBERT_PATH +
+            'distilbert-base-uncased-distilled-squad-pytorch_model.bin',
+            _DISTILBERT_PATH +
+            'distilbert-base-uncased-distilled-squad-config.json',
+            _DISTILBERT_PATH + 'bert-large-uncased-vocab.txt',
+        ],
+    }
+    _MAX_INPUT_SIZE = {
+        'distilbert-base-uncased': 512,
+        'distilbert-base-uncased-distilled-squad': 512,
+    }
+    _VOCAB_FILE_MAP = {
+        'vocab_file': {
+            'distilbert-base-uncased': 'bert-base-uncased-vocab.txt',
+            'distilbert-base-uncased-distilled-squad':
+                'bert-large-uncased-vocab.txt',
+        }
+    }
+
+    @staticmethod
+    def default_hparams():
+        r"""Returns a dictionary of hyperparameters with default values.
+
+        * The tokenizer is determined by the constructor argument
+          :attr:`pretrained_model_name` if it's specified. In this case,
+          `hparams` are ignored.
+        * Otherwise, the tokenizer is determined by
+          `hparams['pretrained_model_name']` if it's specified. All other
+          configurations in `hparams` are ignored.
+        * If the above two are `None`, the tokenizer is defined by the
+          configurations in `hparams`.
+
+        .. code-block:: python
+
+            {
+                "pretrained_model_name": "distilbert-base-uncased",
+                "vocab_file": None,
+                "max_len": 512,
+                "unk_token": "[UNK]",
+                "sep_token": "[SEP]",
+                "pad_token": "[PAD]",
+                "cls_token": "[CLS]",
+                "mask_token": "[MASK]",
+                "tokenize_chinese_chars": True,
+                "do_lower_case": True,
+                "do_basic_tokenize": True,
+                "non_split_tokens": None,
+                "name": "distilbert_tokenizer",
+            }
+
+        Here:
+
+        `"pretrained_model_name"`: str or None
+            The name of the pre-trained DistilBERT model.
+
+        `"vocab_file"`: str or None
+            The path to a one-wordpiece-per-line vocabulary file.
+
+        `"max_len"`: int
+            The maximum sequence length that this model might ever be used with.
+
+        `"unk_token"`: str
+            Unknown token.
+
+        `"sep_token"`: str
+            Separation token.
+
+        `"pad_token"`: str
+            Padding token.
+
+        `"cls_token"`: str
+            Classification token.
+
+        `"mask_token"`: str
+            Masking token.
+
+        `"tokenize_chinese_chars"`: bool
+            Whether to tokenize Chinese characters.
+
+        `"do_lower_case"`: bool
+            Whether to lower case the input
+            Only has an effect when `do_basic_tokenize=True`
+
+        `"do_basic_tokenize"`: bool
+            Whether to do basic tokenization before wordpiece.
+
+        `"non_split_tokens"`: list
+            List of tokens which will never be split during tokenization.
+            Only has an effect when `do_basic_tokenize=True`
+
+        `"name"`: str
+            Name of the tokenizer.
+
+        """
+        return {
+            'pretrained_model_name': 'distilbert-base-uncased',
+            'vocab_file': None,
+            'max_len': 512,
+            'unk_token': '[UNK]',
+            'sep_token': '[SEP]',
+            'pad_token': '[PAD]',
+            'cls_token': '[CLS]',
+            'mask_token': '[MASK]',
+            'tokenize_chinese_chars': True,
+            'do_lower_case': True,
+            'do_basic_tokenize': True,
+            'non_split_tokens': None,
+            'name': 'distilbert_tokenizer',
+            '@no_typecheck': ['pretrained_model_name'],
+        }

--- a/texar/torch/data/tokenizers/pretrained_distilbert_tokenizer_test.py
+++ b/texar/torch/data/tokenizers/pretrained_distilbert_tokenizer_test.py
@@ -1,0 +1,187 @@
+"""
+Unit tests for pre-trained DistilBERT tokenizer.
+"""
+
+import unittest
+
+import os
+import pickle
+import tempfile
+
+from texar.torch.data.tokenizers.pretrained_distilbert_tokenizer import \
+    DistilBERTTokenizer
+from texar.torch.utils.test import pretrained_test
+
+
+class DistilBERTTokenizerTest(unittest.TestCase):
+
+    def setUp(self):
+        vocab_tokens = [
+            "[UNK]", "[CLS]", "[SEP]", "want", "##want", "##ed", "wa", "un",
+            "runn",
+            "##ing", ",", "low", "lowest",
+        ]
+
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.vocab_file = os.path.join(self.tmp_dir.name, 'vocab.txt')
+        with open(self.vocab_file, "w", encoding='utf-8') as vocab_writer:
+            vocab_writer.write("".join([x + "\n" for x in vocab_tokens]))
+
+    def tearDown(self):
+        self.tmp_dir.cleanup()
+
+    @pretrained_test
+    def test_model_loading(self):
+        for pretrained_model_name in \
+                DistilBERTTokenizer.available_checkpoints():
+            tokenizer = DistilBERTTokenizer(
+                pretrained_model_name=pretrained_model_name)
+            _ = tokenizer.map_text_to_token(u"UNwant\u00E9d,running")
+
+    def test_tokenize(self):
+        tokenizer = DistilBERTTokenizer.load(self.vocab_file)
+
+        tokens = tokenizer.map_text_to_token(u"UNwant\u00E9d,running")
+        self.assertListEqual(tokens,
+                             ["un", "##want", "##ed", ",", "runn", "##ing"])
+
+        ids = tokenizer.map_token_to_id(tokens)
+        self.assertListEqual(ids, [7, 4, 5, 10, 8, 9])
+
+    def test_pickle(self):
+        tokenizer = DistilBERTTokenizer.load(self.vocab_file)
+        self.assertIsNotNone(tokenizer)
+
+        text = u"Munich and Berlin are nice cities"
+        subwords = tokenizer.map_text_to_token(text)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            filename = os.path.join(tmpdirname, u"tokenizer.bin")
+            with open(filename, "wb") as f:
+                pickle.dump(tokenizer, f)
+            with open(filename, "rb") as f:
+                tokenizer_new = pickle.load(f)
+
+        subwords_loaded = tokenizer_new.map_text_to_token(text)
+
+        self.assertListEqual(subwords, subwords_loaded)
+
+    def test_save_load(self):
+        tokenizer = DistilBERTTokenizer.load(self.vocab_file)
+
+        before_tokens = tokenizer.map_text_to_id(
+            u"He is very happy, UNwant\u00E9d,running")
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            tokenizer.save(tmpdirname)
+            tokenizer = tokenizer.load(tmpdirname)
+
+        after_tokens = tokenizer.map_text_to_id(
+            u"He is very happy, UNwant\u00E9d,running")
+        self.assertListEqual(before_tokens, after_tokens)
+
+    def test_pretrained_model_list(self):
+        model_list_1 = list(DistilBERTTokenizer._MODEL2URL.keys())
+        model_list_2 = list(DistilBERTTokenizer._MAX_INPUT_SIZE.keys())
+
+        self.assertListEqual(model_list_1, model_list_2)
+
+    def test_encode_decode(self):
+        tokenizer = DistilBERTTokenizer.load(self.vocab_file)
+
+        input_text = u"UNwant\u00E9d,running"
+        output_text = u"unwanted, running"
+
+        tokens = tokenizer.map_text_to_token(input_text)
+        ids = tokenizer.map_token_to_id(tokens)
+        ids_2 = tokenizer.map_text_to_id(input_text)
+        self.assertListEqual(ids, ids_2)
+
+        tokens_2 = tokenizer.map_id_to_token(ids)
+        text_2 = tokenizer.map_id_to_text(ids)
+
+        self.assertEqual(text_2, output_text)
+
+        self.assertNotEqual(len(tokens_2), 0)
+        self.assertIsInstance(text_2, str)
+
+    def test_add_tokens(self):
+        tokenizer = DistilBERTTokenizer.load(self.vocab_file)
+
+        vocab_size = tokenizer.vocab_size
+        all_size = len(tokenizer)
+
+        self.assertNotEqual(vocab_size, 0)
+        self.assertEqual(vocab_size, all_size)
+
+        new_toks = ["aaaaabbbbbb", "cccccccccdddddddd"]
+        added_toks = tokenizer.add_tokens(new_toks)
+        vocab_size_2 = tokenizer.vocab_size
+        all_size_2 = len(tokenizer)
+
+        self.assertNotEqual(vocab_size_2, 0)
+        self.assertEqual(vocab_size, vocab_size_2)
+        self.assertEqual(added_toks, len(new_toks))
+        self.assertEqual(all_size_2, all_size + len(new_toks))
+
+        tokens = tokenizer.map_text_to_id("aaaaabbbbbb low cccccccccdddddddd l")
+        self.assertGreaterEqual(len(tokens), 4)
+        self.assertGreater(tokens[0], tokenizer.vocab_size - 1)
+        self.assertGreater(tokens[-2], tokenizer.vocab_size - 1)
+
+        new_toks_2 = {'eos_token': ">>>>|||<||<<|<<",
+                      'pad_token': "<<<<<|||>|>>>>|>"}
+        added_toks_2 = tokenizer.add_special_tokens(new_toks_2)
+        vocab_size_3 = tokenizer.vocab_size
+        all_size_3 = len(tokenizer)
+
+        self.assertNotEqual(vocab_size_3, 0)
+        self.assertEqual(vocab_size, vocab_size_3)
+        self.assertEqual(added_toks_2, len(new_toks_2))
+        self.assertEqual(all_size_3, all_size_2 + len(new_toks_2))
+
+        tokens = tokenizer.map_text_to_id(
+            ">>>>|||<||<<|<< aaaaabbbbbb low cccccccccdddddddd "
+            "<<<<<|||>|>>>>|> l")
+
+        self.assertGreaterEqual(len(tokens), 6)
+        self.assertGreater(tokens[0], tokenizer.vocab_size - 1)
+        self.assertGreater(tokens[0], tokens[1])
+        self.assertGreater(tokens[-2], tokenizer.vocab_size - 1)
+        self.assertGreater(tokens[-2], tokens[-3])
+        self.assertEqual(tokens[0],
+                         tokenizer.map_token_to_id(tokenizer.eos_token))
+        self.assertEqual(tokens[-2],
+                         tokenizer.map_token_to_id(tokenizer.pad_token))
+
+    def test_encode_text(self):
+        tokenizer = DistilBERTTokenizer.load(self.vocab_file)
+
+        text_1 = u"He is very happy"
+        text_2 = u"unwanted, running"
+
+        text_1_ids = tokenizer.map_text_to_id(text_1)
+        text_2_ids = tokenizer.map_text_to_id(text_2)
+
+        cls_token_id = tokenizer.map_token_to_id(tokenizer.cls_token)
+        sep_token_id = tokenizer.map_token_to_id(tokenizer.sep_token)
+
+        input_ids, segment_ids, input_mask = \
+            tokenizer.encode_text(text_1, None, 4)
+
+        self.assertListEqual(input_ids,
+                             [cls_token_id] + text_1_ids[:2] + [sep_token_id])
+        self.assertListEqual(segment_ids, [0, 0, 0, 0])
+        self.assertListEqual(input_mask, [1, 1, 1, 1])
+
+        input_ids, segment_ids, input_mask = \
+            tokenizer.encode_text(text_1, text_2, 7)
+
+        self.assertListEqual(input_ids, [cls_token_id] + text_1_ids[:2] +
+                             [sep_token_id] + text_2_ids[:2] + [sep_token_id])
+        self.assertListEqual(segment_ids, [0, 0, 0, 0, 1, 1, 1])
+        self.assertListEqual(input_mask, [1, 1, 1, 1, 1, 1, 1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/texar/torch/data/tokenizers/pretrained_gpt2_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_gpt2_tokenizer.py
@@ -69,6 +69,22 @@ class GPT2Tokenizer(PretrainedGPT2Mixin, TokenizerBase):
         'vocab_file': 'encoder.json',
         'merges_file': 'vocab.bpe',
     }
+    _VOCAB_FILE_MAP = {
+        'vocab_file': {
+            'gpt2-small': 'encoder.json',
+            'gpt2-medium': 'encoder.json',
+            'gpt2-large': 'encoder.json',
+            '117M': 'encoder.json',
+            '345M': 'encoder.json',
+        },
+        'merges_file': {
+            'gpt2-small': 'vocab.bpe',
+            'gpt2-medium': 'vocab.bpe',
+            'gpt2-large': 'vocab.bpe',
+            '117M': 'vocab.bpe',
+            '345M': 'vocab.bpe',
+        },
+    }
 
     def __init__(self,
                  pretrained_model_name: Optional[str] = None,
@@ -83,10 +99,13 @@ class GPT2Tokenizer(PretrainedGPT2Mixin, TokenizerBase):
         }
 
         if self.pretrained_model_dir is not None:
+            assert self.pretrained_model_name is not None
             vocab_file = os.path.join(self.pretrained_model_dir,
-                                      self._VOCAB_FILE_NAMES['vocab_file'])
+                                      self._VOCAB_FILE_MAP['vocab_file']
+                                      [self.pretrained_model_name])
             merges_file = os.path.join(self.pretrained_model_dir,
-                                       self._VOCAB_FILE_NAMES['merges_file'])
+                                       self._VOCAB_FILE_MAP['merges_file']
+                                       [self.pretrained_model_name])
             assert pretrained_model_name is not None
             if self._MAX_INPUT_SIZE.get(pretrained_model_name):
                 self.max_len = self._MAX_INPUT_SIZE[pretrained_model_name]
@@ -300,6 +319,7 @@ class GPT2Tokenizer(PretrainedGPT2Mixin, TokenizerBase):
                 "unk_token": "<|endoftext|>",
                 "pad_token": "<|endoftext|>",
                 "errors": "replace",
+                "name": "gpt2_tokenizer",
             }
 
         Here:
@@ -331,6 +351,10 @@ class GPT2Tokenizer(PretrainedGPT2Mixin, TokenizerBase):
         `"errors"`: str
             Response when mapping tokens to text fails. The possible values are
             `ignore`, `replace`, and `strict`.
+
+        `"name"`: str
+            Name of the tokenizer.
+
         """
         return {
             'pretrained_model_name': '117M',
@@ -342,6 +366,7 @@ class GPT2Tokenizer(PretrainedGPT2Mixin, TokenizerBase):
             'unk_token': '<|endoftext|>',
             'pad_token': '<|endoftext|>',
             'errors': 'replace',
+            'name': 'gpt2_tokenizer',
             '@no_typecheck': ['pretrained_model_name'],
         }
 

--- a/texar/torch/data/tokenizers/pretrained_roberta_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_roberta_tokenizer.py
@@ -55,6 +55,16 @@ class RoBERTaTokenizer(GPT2Tokenizer):
         'roberta-base': 512,
         'roberta-large': 512,
     }
+    _VOCAB_FILE_MAP = {
+        'vocab_file': {
+            'roberta-base': 'encoder.json',
+            'roberta-large': 'encoder.json',
+        },
+        'merges_file': {
+            'roberta-base': 'vocab.bpe',
+            'roberta-large': 'vocab.bpe',
+        },
+    }
 
     def encode_text(self,  # type: ignore
                     text_a: str,
@@ -153,6 +163,7 @@ class RoBERTaTokenizer(GPT2Tokenizer):
                 "pad_token": "<pad>",
                 "mask_token": "<mask>",
                 "errors": "replace",
+                "name": "roberta_tokenizer",
             }
 
         Here:
@@ -193,6 +204,10 @@ class RoBERTaTokenizer(GPT2Tokenizer):
         `"errors"`: str
             Response when decoding fails. The possible values are
             `ignore`, `replace`, and `strict`.
+
+        `"name"`: str
+            Name of the tokenizer.
+
         """
         return {
             'pretrained_model_name': 'roberta-base',
@@ -207,6 +222,7 @@ class RoBERTaTokenizer(GPT2Tokenizer):
             'pad_token': '<pad>',
             'mask_token': '<mask>',
             'errors': 'replace',
+            'name': 'roberta_tokenizer',
             '@no_typecheck': ['pretrained_model_name'],
         }
 

--- a/texar/torch/data/tokenizers/pretrained_xlnet_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_xlnet_tokenizer.py
@@ -67,6 +67,12 @@ class XLNetTokenizer(PretrainedXLNetMixin, TokenizerBase):
         'xlnet-large-cased': None,
     }
     _VOCAB_FILE_NAMES = {'vocab_file': 'spiece.model'}
+    _VOCAB_FILE_MAP = {
+        'vocab_file': {
+            'xlnet-base-cased': 'spiece.model',
+            'xlnet-large-cased': 'spiece.model',
+        }
+    }
 
     def __init__(self,
                  pretrained_model_name: Optional[str] = None,
@@ -85,8 +91,10 @@ class XLNetTokenizer(PretrainedXLNetMixin, TokenizerBase):
         }
 
         if self.pretrained_model_dir is not None:
+            assert self.pretrained_model_name is not None
             vocab_file = os.path.join(self.pretrained_model_dir,
-                                      self._VOCAB_FILE_NAMES['vocab_file'])
+                                      self._VOCAB_FILE_MAP['vocab_file']
+                                      [self.pretrained_model_name])
             assert pretrained_model_name is not None
             if self._MAX_INPUT_SIZE.get(pretrained_model_name):
                 self.max_len = self._MAX_INPUT_SIZE[pretrained_model_name]
@@ -304,6 +312,7 @@ class XLNetTokenizer(PretrainedXLNetMixin, TokenizerBase):
                 "do_lower_case": False,
                 "remove_space": True,
                 "keep_accents": False,
+                "name": "xlnet_tokenizer",
             }
 
         Here:
@@ -349,6 +358,10 @@ class XLNetTokenizer(PretrainedXLNetMixin, TokenizerBase):
 
         `"keep_accents"`: bool
             Whether to keep the accents in the text.
+
+        `"name"`: str
+            Name of the tokenizer.
+
         """
         return {
             'pretrained_model_name': 'xlnet-base-cased',
@@ -365,6 +378,7 @@ class XLNetTokenizer(PretrainedXLNetMixin, TokenizerBase):
             'do_lower_case': False,
             'remove_space': True,
             'keep_accents': False,
+            'name': 'xlnet_tokenizer',
             '@no_typecheck': ['pretrained_model_name'],
         }
 

--- a/texar/torch/data/tokenizers/tokenizer_base.py
+++ b/texar/torch/data/tokenizers/tokenizer_base.py
@@ -54,6 +54,7 @@ class TokenizerBase(ModuleBase):
     _IS_PRETRAINED: bool
     _MAX_INPUT_SIZE: Dict[str, Optional[int]]
     _VOCAB_FILE_NAMES: Dict[str, str]
+    _VOCAB_FILE_MAP: Dict[str, Dict[str, str]]
     _SPECIAL_TOKENS_ATTRIBUTES = ["bos_token", "eos_token", "unk_token",
                                   "sep_token", "pad_token", "cls_token",
                                   "mask_token", "additional_special_tokens"]

--- a/texar/torch/modules/classifiers/__init__.py
+++ b/texar/torch/modules/classifiers/__init__.py
@@ -18,6 +18,7 @@ Modules of Texar library classifiers.
 from texar.torch.modules.classifiers.bert_classifier import *
 from texar.torch.modules.classifiers.classifier_base import *
 from texar.torch.modules.classifiers.conv_classifiers import *
+from texar.torch.modules.classifiers.distilbert_classifier import *
 from texar.torch.modules.classifiers.gpt2_classifier import *
 from texar.torch.modules.classifiers.roberta_classifier import *
 from texar.torch.modules.classifiers.xlnet_classifier import *

--- a/texar/torch/modules/classifiers/distilbert_classifier.py
+++ b/texar/torch/modules/classifiers/distilbert_classifier.py
@@ -1,0 +1,178 @@
+# Copyright 2019 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+DistilBERT Classifier.
+"""
+from typing import Optional, Tuple
+
+import torch
+
+from texar.torch.modules.encoders.distilbert_encoder import DistilBERTEncoder
+from texar.torch.modules.classifiers.bert_classifier import BERTClassifier
+from texar.torch.modules.pretrained.pretrained_distilbert import \
+    PretrainedDistilBERTMixin
+
+__all__ = [
+    "DistilBERTClassifier",
+]
+
+
+class DistilBERTClassifier(PretrainedDistilBERTMixin,  # type: ignore
+                           BERTClassifier):
+    r"""Classifier based on DistilBERT modules.
+
+    This is a combination of the
+    :class:`~texar.torch.modules.DistilBERTEncoder` with a classification
+    layer. Both step-wise classification and sequence-level classification
+    are supported, specified in :attr:`hparams`.
+
+    Arguments are the same as in
+    :class:`~texar.torch.modules.DistilBERTEncoder`.
+
+    Args:
+        pretrained_model_name (optional): a `str`, the name
+            of pre-trained model (e.g., ``distilbert-base-uncased``).
+            Please refer to
+            :class:`~texar.torch.modules.PretrainedDistilBERTMixin` for
+            all supported models.
+            If `None`, the model name in :attr:`hparams` is used.
+        cache_dir (optional): the path to a folder in which the
+            pre-trained models will be cached. If `None` (default),
+            a default directory (``texar_data`` folder under user's home
+            directory) will be used.
+        hparams (dict or HParams, optional): Hyperparameters. Missing
+            hyperparameters will be set to default values. See
+            :meth:`default_hparams` for the hyperparameter structure
+            and default values.
+
+    .. document private functions
+    """
+    _ENCODER_CLASS = DistilBERTEncoder
+
+    @staticmethod
+    def default_hparams():
+        r"""Returns a dictionary of hyperparameters with default values.
+
+        .. code-block:: python
+
+            {
+                # (1) Same hyperparameters as in DistilBERTEncoder
+                ...
+                # (2) Additional hyperparameters
+                "num_classes": 2,
+                "logit_layer_kwargs": None,
+                "clas_strategy": "cls_time",
+                "max_seq_length": None,
+                "dropout": 0.1,
+                "name": "distilbert_classifier"
+            }
+
+        Here:
+
+        1. Same hyperparameters as in
+           :class:`~texar.torch.modules.DistilBERTEncoder`.
+           See the
+           :meth:`~texar.torch.modules.DistilBERTEncoder.default_hparams`.
+           An instance of DistilBERTEncoder is created for feature extraction.
+
+        2. Additional hyperparameters:
+
+            `"num_classes"`: int
+                Number of classes:
+
+                - If **> 0**, an additional `Linear`
+                  layer is appended to the encoder to compute the logits over
+                  classes.
+                - If **<= 0**, no dense layer is appended. The number of
+                  classes is assumed to be the final dense layer size of the
+                  encoder.
+
+            `"logit_layer_kwargs"`: dict
+                Keyword arguments for the logit Dense layer constructor,
+                except for argument "units" which is set to `num_classes`.
+                Ignored if no extra logit layer is appended.
+
+            `"clas_strategy"`: str
+                The classification strategy, one of:
+
+                - **cls_time**: Sequence-level classification based on the
+                  output of the first time step (which is the `CLS` token).
+                  Each sequence has a class.
+                - **all_time**: Sequence-level classification based on
+                  the output of all time steps. Each sequence has a class.
+                - **time_wise**: Step-wise classification, i.e., make
+                  classification for each time step based on its output.
+
+            `"max_seq_length"`: int, optional
+                Maximum possible length of input sequences. Required if
+                `clas_strategy` is `all_time`.
+
+            `"dropout"`: float
+                The dropout rate of the DistilBERT encoder output.
+
+            `"name"`: str
+                Name of the classifier.
+        """
+
+        hparams = DistilBERTEncoder.default_hparams()
+        hparams.update({
+            "num_classes": 2,
+            "logit_layer_kwargs": None,
+            "clas_strategy": "cls_time",
+            "max_seq_length": None,
+            "dropout": 0.1,
+            "name": "distilbert_classifier"
+        })
+        return hparams
+
+    def forward(self,  # type: ignore
+                inputs: torch.Tensor,
+                sequence_length: Optional[torch.LongTensor] = None) \
+            -> Tuple[torch.Tensor, torch.LongTensor]:
+        r"""Feeds the inputs through the network and makes classification.
+
+        The arguments are the same as in
+        :class:`~texar.torch.modules.DistilBERTEncoder`.
+
+        Args:
+            inputs: A 2D Tensor of shape `[batch_size, max_time]`,
+                containing the token ids of tokens in input sequences.
+            sequence_length (optional): A 1D Tensor of shape `[batch_size]`.
+                Input tokens beyond respective sequence lengths are masked
+                out automatically.
+
+        Returns:
+            A tuple `(logits, preds)`, containing the logits over classes and
+            the predictions, respectively.
+
+            - If ``clas_strategy`` is ``cls_time`` or ``all_time``:
+
+                - If ``num_classes`` == 1, ``logits`` and ``pred`` are both of
+                  shape ``[batch_size]``.
+                - If ``num_classes`` > 1, ``logits`` is of shape
+                  ``[batch_size, num_classes]`` and ``pred`` is of shape
+                  ``[batch_size]``.
+
+            - If ``clas_strategy`` is ``time_wise``:
+
+                - ``num_classes`` == 1, ``logits`` and ``pred`` are both of
+                  shape ``[batch_size, max_time]``.
+                - If ``num_classes`` > 1, ``logits`` is of shape
+                  ``[batch_size, max_time, num_classes]`` and ``pred`` is of
+                  shape ``[batch_size, max_time]``.
+        """
+        logits, preds = super().forward(inputs=inputs,
+                                        sequence_length=sequence_length,
+                                        segment_ids=None)
+        return logits, preds

--- a/texar/torch/modules/classifiers/distilbert_classifier_test.py
+++ b/texar/torch/modules/classifiers/distilbert_classifier_test.py
@@ -1,0 +1,173 @@
+"""
+Unit tests for DistilBERT classifiers.
+"""
+
+import unittest
+
+import torch
+
+from texar.torch.modules.classifiers.distilbert_classifier import *
+from texar.torch.utils.test import pretrained_test
+
+
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
+
+
+class DistilBERTClassifierTest(unittest.TestCase):
+    r"""Tests :class:`~texar.torch.modules.DistilBERTClassifier` class.
+    """
+
+    def setUp(self) -> None:
+        self.batch_size = 2
+        self.max_length = 3
+        self.inputs = torch.zeros(
+            self.batch_size, self.max_length, dtype=torch.long)
+
+    @pretrained_test
+    def test_model_loading(self):
+        r"""Tests model loading functionality."""
+        for pretrained_model_name in \
+                DistilBERTClassifier.available_checkpoints():
+            classifier = DistilBERTClassifier(
+                pretrained_model_name=pretrained_model_name)
+            _, _ = classifier(self.inputs)
+
+    def test_trainable_variables(self):
+        r"""Tests the functionality of automatically collecting trainable
+        variables.
+        """
+        # case 1
+        hparams = {
+            "pretrained_model_name": None,
+        }
+        classifier = DistilBERTClassifier(hparams=hparams)
+
+        self.assertEqual(len(classifier.trainable_variables), 103)
+        _, _ = classifier(self.inputs)
+
+        # case 2
+        hparams = {
+            "pretrained_model_name": None,
+            "clas_strategy": "all_time",
+            "max_seq_length": 8,
+        }
+        classifier = DistilBERTClassifier(hparams=hparams)
+        self.assertEqual(len(classifier.trainable_variables), 103)
+        _, _ = classifier(self.inputs)
+
+        # case 3
+        hparams = {
+            "pretrained_model_name": None,
+            "clas_strategy": "time_wise",
+        }
+        classifier = DistilBERTClassifier(hparams=hparams)
+        self.assertEqual(len(classifier.trainable_variables), 103)
+        _, _ = classifier(self.inputs)
+
+    def test_classification(self):
+        r"""Tests classification.
+        """
+        inputs = torch.randint(30521, (self.batch_size, self.max_length))
+
+        # case 1
+        hparams = {
+            "pretrained_model_name": None,
+        }
+        classifier = DistilBERTClassifier(hparams=hparams)
+        logits, preds = classifier(inputs)
+
+        self.assertEqual(logits.shape, torch.Size(
+            [self.batch_size, classifier.output_size]))
+        self.assertEqual(preds.shape, torch.Size([self.batch_size]))
+
+        # case 2
+        hparams = {
+            "pretrained_model_name": None,
+            "num_classes": 10,
+            "clas_strategy": "time_wise",
+        }
+        classifier = DistilBERTClassifier(hparams=hparams)
+        logits, preds = classifier(inputs)
+
+        self.assertEqual(logits.shape, torch.Size(
+            [self.batch_size, self.max_length, classifier.output_size]))
+        self.assertEqual(preds.shape, torch.Size(
+            [self.batch_size, self.max_length]))
+
+        # case 3
+        hparams = {
+            "pretrained_model_name": None,
+            "num_classes": 0,
+            "clas_strategy": "time_wise",
+        }
+        classifier = DistilBERTClassifier(hparams=hparams)
+        logits, preds = classifier(inputs)
+
+        self.assertEqual(logits.shape, torch.Size(
+            [self.batch_size, self.max_length, classifier.output_size]))
+        self.assertEqual(preds.shape, torch.Size(
+            [self.batch_size, self.max_length]))
+
+        # case 4
+        hparams = {
+            "pretrained_model_name": None,
+            "num_classes": 10,
+            "clas_strategy": "all_time",
+            "max_seq_length": self.max_length,
+        }
+        classifier = DistilBERTClassifier(hparams=hparams)
+        logits, preds = classifier(inputs)
+
+        self.assertEqual(logits.shape, torch.Size(
+            [self.batch_size, classifier.output_size]))
+        self.assertEqual(preds.shape, torch.Size([self.batch_size]))
+
+    def test_binary(self):
+        r"""Tests binary classification.
+        """
+        inputs = torch.randint(30521, (self.batch_size, self.max_length))
+
+        # case 1
+        hparams = {
+            "pretrained_model_name": None,
+            "num_classes": 1,
+            "clas_strategy": "time_wise",
+        }
+        classifier = DistilBERTClassifier(hparams=hparams)
+        logits, preds = classifier(inputs)
+
+        self.assertEqual(logits.shape, torch.Size(
+            [self.batch_size, self.max_length]))
+        self.assertEqual(preds.shape, torch.Size(
+            [self.batch_size, self.max_length]))
+
+        # case 2
+        hparams = {
+            "pretrained_model_name": None,
+            "num_classes": 1,
+            "clas_strategy": "cls_time",
+            "max_seq_length": self.max_length,
+        }
+        classifier = DistilBERTClassifier(hparams=hparams)
+        logits, preds = classifier(inputs)
+
+        self.assertEqual(logits.shape, torch.Size([self.batch_size]))
+        self.assertEqual(preds.shape, torch.Size([self.batch_size]))
+
+        # case 3
+        hparams = {
+            "pretrained_model_name": None,
+            "num_classes": 1,
+            "clas_strategy": "all_time",
+            "max_seq_length": self.max_length,
+        }
+        classifier = DistilBERTClassifier(hparams=hparams)
+        logits, preds = classifier(inputs)
+
+        self.assertEqual(logits.shape, torch.Size([self.batch_size]))
+        self.assertEqual(preds.shape, torch.Size([self.batch_size]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/texar/torch/modules/encoders/__init__.py
+++ b/texar/torch/modules/encoders/__init__.py
@@ -17,6 +17,7 @@ Modules of Texar library encoders.
 
 from texar.torch.modules.encoders.bert_encoder import *
 from texar.torch.modules.encoders.conv_encoders import *
+from texar.torch.modules.encoders.distilbert_encoder import *
 from texar.torch.modules.encoders.encoder_base import *
 from texar.torch.modules.encoders.gpt2_encoder import *
 from texar.torch.modules.encoders.multihead_attention import *

--- a/texar/torch/modules/encoders/distilbert_encoder.py
+++ b/texar/torch/modules/encoders/distilbert_encoder.py
@@ -12,41 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-BERT encoder.
+DistilBERT encoder.
 """
 
-from typing import Optional, Union
+from typing import Optional
 
 import torch
-from torch import nn
 
-from texar.torch.core import layers
-from texar.torch.modules.embedders.embedders import WordEmbedder
-from texar.torch.modules.embedders.position_embedders import \
-    PositionEmbedder, SinusoidsPositionEmbedder
-from texar.torch.modules.encoders.encoder_base import EncoderBase
-from texar.torch.modules.encoders.transformer_encoder import TransformerEncoder
-from texar.torch.modules.pretrained.pretrained_bert import PretrainedBERTMixin
+from texar.torch.modules.encoders.bert_encoder import BERTEncoder
+from texar.torch.modules.pretrained.pretrained_distilbert import \
+    PretrainedDistilBERTMixin
 
 __all__ = [
-    "BERTEncoder",
+    "DistilBERTEncoder",
 ]
 
 
-class BERTEncoder(EncoderBase, PretrainedBERTMixin):
-    r"""Raw BERT Transformer for encoding sequences.
+class DistilBERTEncoder(PretrainedDistilBERTMixin, BERTEncoder):  # type: ignore
+    r"""DistilBERT Transformer for encoding sequences.
 
     This module basically stacks
     :class:`~texar.torch.modules.WordEmbedder`,
-    :class:`~texar.torch.modules.PositionEmbedder`,
+    :class:`~texar.torch.modules.PositionEmbedder`
+    (or :class:`~texar.torch.modules.SinusoidsPositionEmbedder`),
     :class:`~texar.torch.modules.TransformerEncoder` and a dense
     pooler.
 
     Args:
         pretrained_model_name (optional): a `str`, the name
-            of pre-trained model (e.g., ``bert-base-uncased``). Please refer to
-            :class:`~texar.torch.modules.PretrainedBERTMixin` for
-            all supported models.
+            of pre-trained model (e.g., ``distilbert-base-uncased``). Please
+            refer to :class:`~texar.torch.modules.PretrainedDistilBERTaMixin`
+            for all supported models.
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
@@ -57,55 +53,6 @@ class BERTEncoder(EncoderBase, PretrainedBERTMixin):
             :meth:`default_hparams` for the hyperparameter structure
             and default values.
     """
-
-    def __init__(self,
-                 pretrained_model_name: Optional[str] = None,
-                 cache_dir: Optional[str] = None,
-                 hparams=None):
-        super().__init__(hparams=hparams)
-
-        self.load_pretrained_config(pretrained_model_name, cache_dir)
-
-        # Word embedding
-        self.word_embedder = WordEmbedder(
-            vocab_size=self._hparams.vocab_size,
-            hparams=self._hparams.embed)
-
-        # Segment embedding for each type of tokens
-        self.segment_embedder = None
-        if self._hparams.get('type_vocab_size', 0) > 0:
-            self.segment_embedder = WordEmbedder(
-                vocab_size=self._hparams.type_vocab_size,
-                hparams=self._hparams.segment_embed)
-
-        # Position embedding
-        self.position_embedder: Union[SinusoidsPositionEmbedder,
-                                      PositionEmbedder]
-        if self._hparams.get('use_sinusoidal_pos_embed', False):
-            self.position_embedder = SinusoidsPositionEmbedder(
-                position_size=self._hparams.position_size,
-                hparams=self._hparams.position_embed)
-        else:
-            self.position_embedder = PositionEmbedder(
-                position_size=self._hparams.position_size,
-                hparams=self._hparams.position_embed)
-
-        # The BERT encoder (a TransformerEncoder)
-        self.encoder = TransformerEncoder(hparams=self._hparams.encoder)
-
-        self.pooler = nn.Sequential(
-            nn.Linear(self._hparams.hidden_size, self._hparams.hidden_size),
-            nn.Tanh())
-
-        self.init_pretrained_weights()
-
-    def reset_parameters(self):
-        initialize = layers.get_initializer(self._hparams.initializer)
-        if initialize is not None:
-            # Do not re-initialize LayerNorm modules.
-            for name, param in self.named_parameters():
-                if name.split('.')[-1] == 'weight' and 'layer_norm' not in name:
-                    initialize(param)
 
     @staticmethod
     def default_hparams():
@@ -123,23 +70,18 @@ class BERTEncoder(EncoderBase, PretrainedBERTMixin):
         .. code-block:: python
 
             {
-                "pretrained_model_name": "bert-base-uncased",
+                "pretrained_model_name": "distilbert-base-uncased",
                 "embed": {
                     "dim": 768,
                     "name": "word_embeddings"
                 },
                 "vocab_size": 30522,
-                "segment_embed": {
-                    "dim": 768,
-                    "name": "token_type_embeddings"
-                },
-                "type_vocab_size": 2,
+                "use_sinusoidal_pos_embed": True,
                 "position_embed": {
                     "dim": 768,
                     "name": "position_embeddings"
                 },
                 "position_size": 512,
-
                 "encoder": {
                     "dim": 768,
                     "embedding_dropout": 0.1,
@@ -152,7 +94,7 @@ class BERTEncoder(EncoderBase, PretrainedBERTMixin):
                         "use_bias": True
                     },
                     "name": "encoder",
-                    "num_blocks": 12,
+                    "num_blocks": 6,
                     "poswise_feedforward": {
                         "layers": [
                             {
@@ -179,28 +121,22 @@ class BERTEncoder(EncoderBase, PretrainedBERTMixin):
                     },
                 "hidden_size": 768,
                 "initializer": None,
-                "name": "bert_encoder",
+                "name": "distilbert_encoder",
             }
 
         Here:
 
-        The default parameters are values for uncased BERT-Base model.
+        The default parameters are values for uncased DistilBERT-Base model.
 
         `"pretrained_model_name"`: str or None
-            The name of the pre-trained BERT model. If None, the model
+            The name of the pre-trained DistilBERT model. If None, the model
             will be randomly initialized.
 
         `"embed"`: dict
             Hyperparameters for word embedding layer.
 
         `"vocab_size"`: int
-            The vocabulary size of `inputs` in BERT model.
-
-        `"segment_embed"`: dict
-            Hyperparameters for segment embedding layer.
-
-        `"type_vocab_size"`: int
-            The vocabulary size of the `segment_ids` passed into `BertModel`.
+            The vocabulary size of `inputs` in DistilBERT model.
 
         `"position_embed"`: dict
             Hyperparameters for position embedding layer.
@@ -226,17 +162,13 @@ class BERTEncoder(EncoderBase, PretrainedBERTMixin):
         """
 
         return {
-            'pretrained_model_name': 'bert-base-uncased',
+            'pretrained_model_name': 'distilbert-base-uncased',
             'embed': {
                 'dim': 768,
                 'name': 'word_embeddings'
             },
             'vocab_size': 30522,
-            'segment_embed': {
-                'dim': 768,
-                'name': 'token_type_embeddings'
-            },
-            'type_vocab_size': 2,
+            'use_sinusoidal_pos_embed': True,
             'position_embed': {
                 'dim': 768,
                 'name': 'position_embeddings'
@@ -255,7 +187,7 @@ class BERTEncoder(EncoderBase, PretrainedBERTMixin):
                     'use_bias': True
                 },
                 'name': 'encoder',
-                'num_blocks': 12,
+                'num_blocks': 6,
                 'poswise_feedforward': {
                     'layers': [
                         {
@@ -282,7 +214,7 @@ class BERTEncoder(EncoderBase, PretrainedBERTMixin):
             },
             'hidden_size': 768,
             'initializer': None,
-            'name': 'bert_encoder',
+            'name': 'distilbert_encoder',
             '@no_typecheck': ['pretrained_model_name']
         }
 
@@ -290,15 +222,13 @@ class BERTEncoder(EncoderBase, PretrainedBERTMixin):
                 inputs: torch.Tensor,
                 sequence_length: Optional[torch.LongTensor] = None,
                 segment_ids: Optional[torch.LongTensor] = None):
-        r"""Encodes the inputs.
+        r"""Encodes the inputs. Differing from the standard BERT, the DistilBERT
+        model does not use segmentation embedding. As a result, DistilBERT
+        does not require `segment_ids` as an input.
 
         Args:
             inputs: A 2D Tensor of shape `[batch_size, max_time]`,
                 containing the token ids of tokens in the input sequences.
-            segment_ids (optional): A 2D Tensor of shape
-                `[batch_size, max_time]`, containing the segment ids
-                of tokens in input sequences. If `None` (default), a
-                tensor with all elements set to zero is used.
             sequence_length (optional): A 1D Tensor of shape `[batch_size]`.
                 Input tokens beyond respective sequence lengths are masked
                 out automatically.
@@ -312,39 +242,13 @@ class BERTEncoder(EncoderBase, PretrainedBERTMixin):
             - :attr:`pooled_output`: A Tensor of size
               `[batch_size, hidden_size]` which is the output of a pooler
               pre-trained on top of the hidden state associated to the first
-              character of the input (`CLS`), see BERT's paper.
+              character of the input (`CLS`), see RoBERTa's paper.
         """
+        if segment_ids is not None:
+            raise ValueError("segment_ids should be None in DistilBERTEncoder.")
 
-        word_embeds = self.word_embedder(inputs)
-        batch_size = inputs.size(0)
-        pos_length = inputs.new_full((batch_size,), inputs.size(1),
-                                     dtype=torch.int64)
-        pos_embeds = self.position_embedder(sequence_length=pos_length)
-
-        if self.segment_embedder is not None:
-            if segment_ids is None:
-                segment_ids = torch.zeros_like(inputs)
-            segment_embeds = self.segment_embedder(segment_ids)
-            inputs_embeds = word_embeds + segment_embeds + pos_embeds
-        else:
-            inputs_embeds = word_embeds + pos_embeds
-
-        if sequence_length is None:
-            sequence_length = inputs.new_full((batch_size,), inputs.size(1),
-                                              dtype=torch.int64)
-
-        output = self.encoder(inputs_embeds, sequence_length)
-
-        # taking the hidden state corresponding to the first token.
-        first_token_tensor = output[:, 0, :]
-
-        pooled_output = self.pooler(first_token_tensor)
+        output, pooled_output = super().forward(inputs=inputs,
+                                                sequence_length=sequence_length,
+                                                segment_ids=None)
 
         return output, pooled_output
-
-    @property
-    def output_size(self):
-        r"""The feature size of :meth:`forward` output
-        :attr:`pooled_output`.
-        """
-        return self._hparams.hidden_size

--- a/texar/torch/modules/encoders/distilbert_encoder_test.py
+++ b/texar/torch/modules/encoders/distilbert_encoder_test.py
@@ -1,0 +1,175 @@
+"""
+Unit tests for DistilBERT encoders.
+"""
+
+import unittest
+
+import torch
+
+from texar.torch.modules.encoders.distilbert_encoder import DistilBERTEncoder
+from texar.torch.utils.test import pretrained_test
+
+
+class DistilBERTEncoderTest(unittest.TestCase):
+    r"""Tests :class:`~texar.torch.modules.DistilBERTEncoder` class.
+    """
+
+    def setUp(self) -> None:
+        self.batch_size = 2
+        self.max_length = 3
+        self.inputs = torch.zeros(
+            self.batch_size, self.max_length, dtype=torch.long)
+
+    @pretrained_test
+    def test_model_loading(self):
+        r"""Tests model loading functionality."""
+        for pretrained_model_name in DistilBERTEncoder.available_checkpoints():
+            encoder = DistilBERTEncoder(
+                pretrained_model_name=pretrained_model_name)
+            _, _ = encoder(self.inputs)
+
+    @pretrained_test
+    def test_hparams(self):
+        r"""Tests the priority of the encoder arch parameter.
+        """
+        # case 1: set "pretrained_mode_name" by constructor argument
+        hparams = {
+            "pretrained_model_name": "distilbert-base-uncased-squad",
+        }
+        encoder = DistilBERTEncoder(
+            pretrained_model_name="distilbert-base-uncased",
+            hparams=hparams)
+        self.assertEqual(encoder.hparams.encoder.num_blocks, 6)
+        _, _ = encoder(self.inputs)
+
+        # case 2: set "pretrained_mode_name" by hparams
+        hparams = {
+            "pretrained_model_name": "distilbert-base-uncased-squad",
+            "encoder": {
+                "num_blocks": 12,
+            }
+        }
+        encoder = DistilBERTEncoder(hparams=hparams)
+        self.assertEqual(encoder.hparams.encoder.num_blocks, 6)
+        _, _ = encoder(self.inputs)
+
+        # case 3: set to None in both hparams and constructor argument
+        hparams = {
+            "pretrained_model_name": None,
+            "encoder": {
+                "num_blocks": 12,
+            },
+        }
+        encoder = DistilBERTEncoder(hparams=hparams)
+        self.assertEqual(encoder.hparams.encoder.num_blocks, 12)
+        _, _ = encoder(self.inputs)
+
+        # case 4: using default hparams
+        encoder = DistilBERTEncoder()
+        self.assertEqual(encoder.hparams.encoder.num_blocks, 6)
+        _, _ = encoder(self.inputs)
+
+    @pretrained_test
+    def test_trainable_variables(self):
+        r"""Tests the functionality of automatically collecting trainable
+        variables.
+        """
+        # case 1
+        encoder = DistilBERTEncoder()
+        self.assertEqual(len(encoder.trainable_variables), 3 + 6 * 16 + 2)
+        _, _ = encoder(self.inputs)
+
+        # case 2
+        hparams = {
+            "pretrained_model_name": "distilbert-base-uncased-squad"
+        }
+        encoder = DistilBERTEncoder(hparams=hparams)
+        self.assertEqual(len(encoder.trainable_variables), 3 + 6 * 16 + 2)
+        _, _ = encoder(self.inputs)
+
+        # case 3: self-designed bert
+        hparams = {
+            "encoder": {
+                "num_blocks": 12,
+            },
+            "pretrained_model_name": None,
+        }
+        encoder = DistilBERTEncoder(hparams=hparams)
+        self.assertEqual(len(encoder.trainable_variables), 3 + 12 * 16 + 2)
+        _, _ = encoder(self.inputs)
+
+    def test_encode(self):
+        r"""Tests encoding.
+        """
+        # case 1
+        hparams = {
+            "pretrained_model_name": None,
+        }
+        encoder = DistilBERTEncoder(hparams=hparams)
+
+        inputs = torch.randint(30521, (self.batch_size, self.max_length))
+        outputs, pooled_output = encoder(inputs)
+
+        outputs_dim = encoder.hparams.encoder.dim
+        self.assertEqual(
+            outputs.shape,
+            torch.Size([self.batch_size, self.max_length, outputs_dim]))
+        self.assertEqual(
+            pooled_output.shape,
+            torch.Size([self.batch_size, encoder.output_size]))
+
+        # case 2: self-designed bert
+        hparams = {
+            'pretrained_model_name': None,
+            'embed': {
+                'dim': 96,
+            },
+            'position_embed': {
+                'dim': 96,
+            },
+
+            'encoder': {
+                'dim': 96,
+                'multihead_attention': {
+                    'num_units': 96,
+                    'output_dim': 96,
+                },
+                'poswise_feedforward': {
+                    'layers': [
+                        {
+                            'kwargs': {
+                                'in_features': 96,
+                                'out_features': 96 * 4,
+                                'bias': True,
+                            },
+                            'type': 'Linear',
+                        },
+                        {"type": "BertGELU"},
+                        {
+                            'kwargs': {
+                                'in_features': 96 * 4,
+                                'out_features': 96,
+                                'bias': True,
+                            },
+                            'type': 'Linear',
+                        }
+                    ]
+                },
+            },
+            'hidden_size': 96,
+        }
+        encoder = DistilBERTEncoder(hparams=hparams)
+
+        outputs, pooled_output = encoder(inputs)
+
+        outputs_dim = encoder.hparams.encoder.dim
+        self.assertEqual(
+            outputs.shape,
+            torch.Size([self.batch_size, self.max_length, outputs_dim]))
+        self.assertEqual(
+            pooled_output.shape,
+            torch.Size([self.batch_size, encoder.output_size]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/texar/torch/modules/pretrained/__init__.py
+++ b/texar/torch/modules/pretrained/__init__.py
@@ -17,6 +17,7 @@ Pre-trained modules of Texar library.
 
 from texar.torch.modules.pretrained.pretrained_base import *
 from texar.torch.modules.pretrained.pretrained_bert import *
+from texar.torch.modules.pretrained.pretrained_distilbert import *
 from texar.torch.modules.pretrained.pretrained_gpt2 import *
 from texar.torch.modules.pretrained.pretrained_roberta import *
 from texar.torch.modules.pretrained.pretrained_xlnet import *

--- a/texar/torch/modules/pretrained/pretrained_distilbert.py
+++ b/texar/torch/modules/pretrained/pretrained_distilbert.py
@@ -1,0 +1,202 @@
+# Copyright 2019 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Utils of DistilBERT Modules.
+"""
+
+import json
+import os
+from abc import ABC
+from typing import Any, Dict
+
+import torch
+
+from texar.torch.modules.pretrained.pretrained_base import PretrainedMixin
+
+__all__ = [
+    "PretrainedDistilBERTMixin",
+]
+
+_DISTILBERT_PATH = "https://s3.amazonaws.com/models.huggingface.co/bert/"
+
+
+class PretrainedDistilBERTMixin(PretrainedMixin, ABC):
+    r"""A mixin class to support loading pre-trained checkpoints for modules
+    that implements the DistilBERT model.
+
+    The DistilBERT model was proposed in (`Sanh et al.`. 2019)
+    `Smaller, faster, cheaper, lighter: Introducing DistilBERT, a distilled version of BERT`_
+    . A distilled model trained from the supervision of BERT. Available model
+    names include:
+
+      * ``distilbert-base-uncased``: 6-layer, 768-hidden. 12 heads,
+        66M parameters.
+      * ``distilbert-base-uncased-distilled-squad``: A fine-tuned version of
+        ``distilbert-base-uncased`` fine tuned using knowledge distillation
+        on SQuAD 1.0.
+
+    We provide the following DistilBERT classes:
+
+      * :class:`~texar.torch.modules.DistilBERTEncoder` for text encoding.
+      * :class:`~texar.torch.modules.DistilBERTClassifier` for text
+        classification and sequence tagging.
+
+    .. _`Smaller, faster, cheaper, lighter: Introducing DistilBERT, a distilled version of BERT`:
+        https://medium.com/huggingface/distilbert-8cf3380435b5
+    """
+
+    _MODEL_NAME = "DistilBERT"
+    _MODEL2URL = {
+        'distilbert-base-uncased': [
+            _DISTILBERT_PATH + 'distilbert-base-uncased-pytorch_model.bin',
+            _DISTILBERT_PATH + 'distilbert-base-uncased-config.json',
+            _DISTILBERT_PATH + 'bert-base-uncased-vocab.txt',
+        ],
+        'distilbert-base-uncased-distilled-squad': [
+            _DISTILBERT_PATH +
+            'distilbert-base-uncased-distilled-squad-pytorch_model.bin',
+            _DISTILBERT_PATH +
+            'distilbert-base-uncased-distilled-squad-config.json',
+            _DISTILBERT_PATH + 'bert-large-uncased-vocab.txt',
+        ],
+    }
+
+    @classmethod
+    def _transform_config(cls, pretrained_model_name: str,
+                          cache_dir: str) -> Dict[str, Any]:
+        info = list(os.walk(cache_dir))
+        root, _, files = info[0]
+        config_path = None
+
+        for file in files:
+            if file.endswith('config.json'):
+                config_path = os.path.join(root, file)
+                with open(config_path) as f:
+                    config_ckpt = json.loads(f.read())
+
+        if config_path is None:
+            raise ValueError(f"Cannot find the config file in {cache_dir}")
+
+        configs = {
+            'hidden_size': config_ckpt['dim'],
+            'embed': {
+                'name': 'word_embeddings',
+                'dim': config_ckpt['dim']
+            },
+            'vocab_size': config_ckpt['vocab_size'],
+            'use_sinusoidal_pos_embed': config_ckpt['sinusoidal_pos_embds'],
+            'position_embed': {
+                'name': 'position_embeddings',
+                'dim': config_ckpt['dim']
+            },
+            'position_size': config_ckpt['max_position_embeddings'],
+            'encoder': {
+                'name': 'encoder',
+                'embedding_dropout': config_ckpt['dropout'],
+                'num_blocks': config_ckpt['n_layers'],
+                'multihead_attention': {
+                    'use_bias': True,
+                    'num_units': config_ckpt['dim'],
+                    'num_heads': config_ckpt['n_heads'],
+                    'output_dim': config_ckpt['dim'],
+                    'dropout_rate': config_ckpt['attention_dropout'],
+                    'name': 'self'
+                },
+                'residual_dropout': config_ckpt['dropout'],
+                'dim': config_ckpt['dim'],
+                'use_bert_config': True,
+                'poswise_feedforward': {
+                    "layers": [{
+                        'type': 'Linear',
+                        'kwargs': {
+                            'in_features': config_ckpt['dim'],
+                            'out_features': config_ckpt['hidden_dim'],
+                            'bias': True,
+                        }
+                    }, {
+                        'type': 'Bert' + config_ckpt['activation'].upper()
+                    }, {
+                        'type': 'Linear',
+                        'kwargs': {
+                            'in_features': config_ckpt['hidden_dim'],
+                            'out_features': config_ckpt['dim'],
+                            'bias': True,
+                        }
+                    }],
+                },
+            }
+        }
+
+        return configs
+
+    def _init_from_checkpoint(self, pretrained_model_name: str,
+                              cache_dir: str, **kwargs):
+
+        global_tensor_map = {
+            'distilbert.embeddings.word_embeddings.weight':
+                'word_embedder._embedding',
+            'distilbert.embeddings.position_embeddings.weight':
+                'position_embedder.signal',
+            'distilbert.embeddings.LayerNorm.weight':
+                'encoder.input_normalizer.weight',
+            'distilbert.embeddings.LayerNorm.bias':
+                'encoder.input_normalizer.bias',
+        }
+
+        attention_tensor_map = {
+            'attention.q_lin.weight': 'encoder.self_attns.{}.Q_dense.weight',
+            'attention.q_lin.bias': 'encoder.self_attns.{}.Q_dense.bias',
+            'attention.k_lin.weight': 'encoder.self_attns.{}.K_dense.weight',
+            'attention.k_lin.bias': 'encoder.self_attns.{}.K_dense.bias',
+            'attention.v_lin.weight': 'encoder.self_attns.{}.V_dense.weight',
+            'attention.v_lin.bias': 'encoder.self_attns.{}.V_dense.bias',
+            'attention.out_lin.weight': 'encoder.self_attns.{}.O_dense.weight',
+            'attention.out_lin.bias': 'encoder.self_attns.{}.O_dense.bias',
+            'sa_layer_norm.weight': 'encoder.poswise_layer_norm.{}.weight',
+            'sa_layer_norm.bias': 'encoder.poswise_layer_norm.{}.bias',
+            'ffn.lin1.weight': 'encoder.poswise_networks.{}._layers.0.weight',
+            'ffn.lin1.bias': 'encoder.poswise_networks.{}._layers.0.bias',
+            'ffn.lin2.weight': 'encoder.poswise_networks.{}._layers.2.weight',
+            'ffn.lin2.bias': 'encoder.poswise_networks.{}._layers.2.bias',
+            'output_layer_norm.weight': 'encoder.output_layer_norm.{}.weight',
+            'output_layer_norm.bias': 'encoder.output_layer_norm.{}.bias',
+        }
+
+        info = list(os.walk(cache_dir))
+        root, _, files = info[0]
+        checkpoint_path = None
+
+        for file in files:
+            if file.endswith('model.bin'):
+                checkpoint_path = os.path.join(root, file)
+
+        assert checkpoint_path is not None
+        device = next(self.parameters()).device
+        params = torch.load(checkpoint_path, map_location=device)
+
+        for name, tensor in params.items():
+            if name in global_tensor_map:
+                v_name = global_tensor_map[name]
+                pointer = self._name_to_variable(v_name)
+                assert pointer.shape == tensor.shape
+                pointer.data = tensor.data.type(pointer.dtype)
+            elif name.startswith('distilbert.transformer.layer.'):
+                name = name.lstrip('distilbert.transformer.layer.')
+                layer_num, layer_name = name[0], name[2:]
+                if layer_name in attention_tensor_map:
+                    v_names = attention_tensor_map[layer_name]
+                    pointer = self._name_to_variable(
+                        v_names.format(layer_num))
+                    assert pointer.shape == tensor.shape
+                    pointer.data = tensor.data.type(pointer.dtype)

--- a/texar/torch/modules/pretrained/pretrained_distilbert_test.py
+++ b/texar/torch/modules/pretrained/pretrained_distilbert_test.py
@@ -1,0 +1,87 @@
+"""
+Unit tests for DistilBERT utils.
+"""
+
+import os
+import unittest
+
+from texar.torch.modules.pretrained.pretrained_distilbert import *
+from texar.torch.utils.test import pretrained_test
+
+
+class DistilBERTUtilsTest(unittest.TestCase):
+    r"""Tests DistilBERT utils.
+    """
+
+    @pretrained_test
+    def test_load_pretrained_distilbert_AND_transform_to_texar_config(self):
+
+        pretrained_model_dir = PretrainedDistilBERTMixin.download_checkpoint(
+            pretrained_model_name="distilbert-base-uncased")
+
+        info = list(os.walk(pretrained_model_dir))
+        _, _, files = info[0]
+        self.assertIn('distilbert-base-uncased-pytorch_model.bin', files)
+        self.assertIn('distilbert-base-uncased-config.json', files)
+
+        model_config = PretrainedDistilBERTMixin._transform_config(
+            pretrained_model_name="distilbert-base-uncased",
+            cache_dir=pretrained_model_dir)
+
+        exp_config = {
+            'hidden_size': 768,
+            'embed': {
+                'name': 'word_embeddings',
+                'dim': 768
+            },
+            'vocab_size': 30522,
+            'use_sinusoidal_pos_embed': True,
+            'position_embed': {
+                'name': 'position_embeddings',
+                'dim': 768
+            },
+            'position_size': 512,
+            'encoder': {
+                'name': 'encoder',
+                'embedding_dropout': 0.1,
+                'num_blocks': 6,
+                'multihead_attention': {
+                    'use_bias': True,
+                    'num_units': 768,
+                    'num_heads': 12,
+                    'output_dim': 768,
+                    'dropout_rate': 0.1,
+                    'name': 'self'
+                },
+                'residual_dropout': 0.1,
+                'dim': 768,
+                'use_bert_config': True,
+                'poswise_feedforward': {
+                    'layers': [
+                        {
+                            'type': 'Linear',
+                            'kwargs': {
+                                'in_features': 768,
+                                'out_features': 3072,
+                                'bias': True
+                            }
+                        },
+                        {'type': 'BertGELU'},
+                        {
+                            'type': 'Linear',
+                            'kwargs': {
+                                'in_features': 3072,
+                                'out_features': 768,
+                                'bias': True
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+        self.assertDictEqual(model_config, exp_config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Knowledge distillation is a compression technique in which a small model (`DistilBERT`) is trained to reproduce the behavior of a larger model (`BERT`). In the teacher-student training, they train a student network (`DistilBERT`) to mimic the full output distribution of the teacher network (`BERT`).

The distillation training procedure is summarized as follows.

```python
import torch
import torch.nn as nn
import torch.nn.functional as F
from torch.optim import Optimizer

KD_loss = nn.KLDivLoss(reduction='batchmean')

def kd_step(teacher: nn.Module,
            student: nn.Module,
            temperature: float,
            inputs: torch.tensor,
            optimizer: Optimizer):
    teacher.eval()
    student.train()
    
    with torch.no_grad():
        logits_t = teacher(inputs=inputs)
    logits_s = student(inputs=inputs)
    
    loss = KD_loss(input=F.log_softmax(logits_s/temperature, dim=-1),
                   target=F.softmax(logits_t/temperature, dim=-1))
    
    loss.backward()
    optimizer.step()
    optimizer.zero_grad()
```

The architecture of `DistilBERT` is very similar to that of `BERT`, except:

`DistilBERT` reduces the number of layers by a factor of two.

`DistilBERT` removes the next sentence prediction objective so that there is no `segment_embedding` and `pooler` in the pre-training procedure.

`DistilBERT` uses sinusoidal position embedding during training, and such an embedding matrix is initialized from `bert-base-uncased`.


